### PR TITLE
Include `dotnet_8` image for `egg-t-modloader`

### DIFF
--- a/terraria/tmodloader/egg-t-modloader.json
+++ b/terraria/tmodloader/egg-t-modloader.json
@@ -4,12 +4,13 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-01-02T11:03:56+01:00",
+    "exported_at": "2024-04-24T17:27:29+02:00",
     "name": "tModloader",
     "author": "parker@parkervcp.com",
     "description": "tModLoader is essentially a mod that provides a way to load your own mods without having to work directly with Terraria's source code itself. This means you can easily make mods that are compatible with other people's mods, save yourself the trouble of having to decompile and recompile Terraria.exe, and escape from having to understand all of the obscure \"intricacies\" of Terraria's source code. It is made to work for Terraria 1.3+.",
     "features": null,
     "docker_images": {
+        "Dotnet 8": "ghcr.io\/parkervcp\/yolks:dotnet_8",
         "Dotnet 6": "ghcr.io\/parkervcp\/yolks:dotnet_6"
     },
     "file_denylist": [],


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

This will fix the "You must install or upgrade .NET to run this application" issue with newer tModLoader.

I discovered that someone had already reported it (https://github.com/pelican-eggs/eggs/issues/2910), but decided to leave the rest in the dark, but with his "update the yolk" clue, I was able to figure it out myself.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
